### PR TITLE
nueva table con discovery job y no json

### DIFF
--- a/db_youtube_transcripts/discovery_job_manager.py
+++ b/db_youtube_transcripts/discovery_job_manager.py
@@ -1,0 +1,149 @@
+"""PostgreSQL-backed storage for short-lived discovery and orchestration jobs."""
+
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+
+from .database import get_db_connection, get_db_transaction
+
+
+logger = logging.getLogger(__name__)
+
+
+def _json_payload(value: Dict[str, Any]) -> str:
+    return json.dumps(value, default=str, ensure_ascii=False)
+
+
+class DiscoveryJobManager:
+    """Shared job state for work that must survive process and replica changes."""
+
+    @staticmethod
+    async def create_job(
+        job_id: str,
+        job_type: str,
+        source_type: Optional[str],
+        source_id: Optional[str],
+        payload: Dict[str, Any],
+        ttl_hours: int = 48,
+    ) -> str:
+        job_payload = dict(payload)
+        job_payload["job_id"] = job_id
+        status = str(job_payload.get("status", "processing"))
+
+        async with get_db_transaction() as tx:
+            # Opportunistic cleanup keeps this intentionally small table bounded
+            # without requiring another scheduler.
+            await tx.execute(
+                "DELETE FROM video_discovery_jobs WHERE expires_at <= NOW()"
+            )
+            await tx.execute(
+                """
+                INSERT INTO video_discovery_jobs (
+                    job_id, job_type, source_type, source_id, status,
+                    payload, expires_at
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6::jsonb,
+                    NOW() + make_interval(hours => $7::int)
+                )
+                """,
+                job_id,
+                job_type,
+                source_type,
+                source_id,
+                status,
+                _json_payload(job_payload),
+                ttl_hours,
+            )
+        return job_id
+
+    @staticmethod
+    async def update_job(job_id: str, **updates: Any) -> Optional[Dict[str, Any]]:
+        if not updates:
+            return await DiscoveryJobManager.get_job(job_id)
+
+        updates = dict(updates)
+        status = updates.get("status")
+        error_message = updates.get("error") or updates.get("error_message")
+        is_terminal = status in {"completed", "completed_with_errors", "failed"}
+
+        async with get_db_connection() as conn:
+            record = await conn.fetchrow(
+                """
+                UPDATE video_discovery_jobs
+                SET payload = payload || $2::jsonb,
+                    status = COALESCE($3, status),
+                    error_message = COALESCE($4, error_message),
+                    completed_at = CASE
+                        WHEN $5 THEN COALESCE(completed_at, NOW())
+                        ELSE completed_at
+                    END,
+                    updated_at = NOW()
+                WHERE job_id = $1
+                  AND expires_at > NOW()
+                  AND status NOT IN ('completed', 'completed_with_errors', 'failed')
+                RETURNING payload, status, error_message
+                """,
+                job_id,
+                _json_payload(updates),
+                status,
+                error_message,
+                is_terminal,
+            )
+        return DiscoveryJobManager._record_to_job(record)
+
+    @staticmethod
+    async def get_job(
+        job_id: str, stale_after_minutes: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
+        async with get_db_transaction() as tx:
+            if stale_after_minutes:
+                timeout_message = (
+                    "Discovery worker stopped reporting progress. Please try again."
+                )
+                timeout_payload = {
+                    "status": "failed",
+                    "error": timeout_message,
+                    "end_time": time.time(),
+                }
+                await tx.execute(
+                    """
+                    UPDATE video_discovery_jobs
+                    SET status = 'failed',
+                        error_message = $3,
+                        payload = payload || $4::jsonb,
+                        completed_at = COALESCE(completed_at, NOW()),
+                        updated_at = NOW()
+                    WHERE job_id = $1
+                      AND status IN ('queued', 'processing')
+                      AND updated_at < NOW() - make_interval(mins => $2::int)
+                      AND expires_at > NOW()
+                    """,
+                    job_id,
+                    stale_after_minutes,
+                    timeout_message,
+                    _json_payload(timeout_payload),
+                )
+
+            record = await tx.fetchrow(
+                """
+                SELECT payload, status, error_message
+                FROM video_discovery_jobs
+                WHERE job_id = $1 AND expires_at > NOW()
+                """,
+                job_id,
+            )
+        return DiscoveryJobManager._record_to_job(record)
+
+    @staticmethod
+    def _record_to_job(record: Any) -> Optional[Dict[str, Any]]:
+        if not record:
+            return None
+        payload = record["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        result = dict(payload or {})
+        result["status"] = record["status"]
+        if record["error_message"] and not result.get("error"):
+            result["error"] = record["error_message"]
+        return result

--- a/db_youtube_transcripts/migration_add_video_discovery_jobs.py
+++ b/db_youtube_transcripts/migration_add_video_discovery_jobs.py
@@ -1,0 +1,44 @@
+"""Create shared storage for video and playlist discovery jobs.
+
+Run before deploying the application changes:
+    python -m db_youtube_transcripts.migration_add_video_discovery_jobs
+"""
+
+import asyncio
+
+from .database import close_db_pool, get_db_connection, init_db_pool
+
+
+async def migrate() -> None:
+    await init_db_pool()
+    try:
+        async with get_db_connection() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS video_discovery_jobs (
+                        job_id UUID PRIMARY KEY,
+                        job_type VARCHAR(50) NOT NULL,
+                        source_type VARCHAR(20) NULL,
+                        source_id TEXT NULL,
+                        status VARCHAR(30) NOT NULL DEFAULT 'processing',
+                        payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+                        error_message TEXT NULL,
+                        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                        updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                        completed_at TIMESTAMP NULL,
+                        expires_at TIMESTAMP NOT NULL DEFAULT NOW() + INTERVAL '48 hours'
+                    );
+
+                    CREATE INDEX IF NOT EXISTS idx_video_discovery_jobs_status
+                        ON video_discovery_jobs(status);
+                    CREATE INDEX IF NOT EXISTS idx_video_discovery_jobs_expires_at
+                        ON video_discovery_jobs(expires_at);
+                    """
+                )
+    finally:
+        await close_db_pool()
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/db_youtube_transcripts/schema.py
+++ b/db_youtube_transcripts/schema.py
@@ -130,6 +130,22 @@ with connection.cursor() as c:
     );
     """
 
+    discovery_jobs_query = """
+    CREATE TABLE IF NOT EXISTS video_discovery_jobs (
+        job_id UUID PRIMARY KEY,
+        job_type VARCHAR(50) NOT NULL,
+        source_type VARCHAR(20) NULL,
+        source_id TEXT NULL,
+        status VARCHAR(30) NOT NULL DEFAULT 'processing',
+        payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+        error_message TEXT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        completed_at TIMESTAMP NULL,
+        expires_at TIMESTAMP NOT NULL DEFAULT NOW() + INTERVAL '48 hours'
+    );
+    """
+
     # Create indexes for performance
     indexes_query = """
     -- Jobs table indexes
@@ -145,6 +161,8 @@ with connection.cursor() as c:
     CREATE INDEX IF NOT EXISTS idx_job_videos_duration_category ON job_videos(duration_category);
     CREATE INDEX IF NOT EXISTS idx_job_videos_processed_at ON job_videos(processed_at);
     CREATE INDEX IF NOT EXISTS idx_job_videos_language ON job_videos(language);
+    CREATE INDEX IF NOT EXISTS idx_video_discovery_jobs_status ON video_discovery_jobs(status);
+    CREATE INDEX IF NOT EXISTS idx_video_discovery_jobs_expires_at ON video_discovery_jobs(expires_at);
     """
 
     # Add triggers for updated_at timestamps
@@ -179,6 +197,7 @@ with connection.cursor() as c:
         # Execute job_videos table creation
         print("Creating job_videos table...")
         c.execute(job_videos_query)
+        c.execute(discovery_jobs_query)
         print("✓ Job_videos table created successfully")
 
         # Execute indexes creation

--- a/src/transcript_api.py
+++ b/src/transcript_api.py
@@ -65,6 +65,7 @@ from config_v2 import settings
 # Import hybrid job manager for database operations
 from hybrid_job_manager import hybrid_job_manager
 from job_result_processor import process_video_completion, process_video_failure
+from db_youtube_transcripts.discovery_job_manager import DiscoveryJobManager
 
 # Import API key authentication for developer API
 from api_key_auth import (
@@ -1570,73 +1571,34 @@ async def delete_api_key(
 
 
 # =============================================
-# VIDEO JOBS PERSISTENT STORAGE
+# SHARED DISCOVERY JOB STORAGE
 # =============================================
 
 
-def save_video_job_to_file(job_id: str, job_data: Dict[str, Any]) -> None:
-    """Save video job data to persistent storage"""
-    try:
-        file_path = os.path.join(VIDEO_JOBS_STORAGE_DIR, f"{job_id}.json")
-
-        # Convert data to JSON serializable format
-        serializable_data = {}
-        for key, value in job_data.items():
-            if isinstance(value, (dict, list, str, int, float, bool)) or value is None:
-                serializable_data[key] = value
-            else:
-                # Convert other types to string representation
-                serializable_data[key] = str(value)
-
-        with open(file_path, "w", encoding="utf-8") as f:
-            json.dump(serializable_data, f, indent=2, ensure_ascii=False)
-
-        logger.debug(f"Saved video job {job_id} to file")
-
-    except Exception as e:
-        logger.error(f"Failed to save video job {job_id} to file: {e}")
+async def create_discovery_job(
+    job_id: str,
+    job_data: Dict[str, Any],
+    *,
+    job_type: str,
+    source_type: Optional[str] = None,
+    source_id: Optional[str] = None,
+) -> str:
+    """Create shared job state before returning an ID to a caller."""
+    return await DiscoveryJobManager.create_job(
+        job_id, job_type, source_type, source_id, job_data
+    )
 
 
-def load_video_job_from_file(job_id: str) -> Optional[Dict[str, Any]]:
-    """Load video job data from persistent storage"""
-    try:
-        file_path = os.path.join(VIDEO_JOBS_STORAGE_DIR, f"{job_id}.json")
-
-        if not os.path.exists(file_path):
-            return None
-
-        with open(file_path, "r", encoding="utf-8") as f:
-            job_data = json.load(f)
-
-        logger.debug(f"Loaded video job {job_id} from file")
-        return job_data
-
-    except Exception as e:
-        logger.error(f"Failed to load video job {job_id} from file: {e}")
-        return None
+async def load_discovery_job(
+    job_id: str, *, stale_after_minutes: Optional[int] = None
+) -> Optional[Dict[str, Any]]:
+    return await DiscoveryJobManager.get_job(job_id, stale_after_minutes)
 
 
-def update_video_job(job_id: str, **updates) -> Optional[Dict[str, Any]]:
-    """Update video job data with atomic file operations"""
-    try:
-        # Load current job data
-        job_data = load_video_job_from_file(job_id)
-        if job_data is None:
-            logger.error(f"Video job {job_id} not found for update")
-            return None
-
-        # Apply updates
-        for key, value in updates.items():
-            job_data[key] = value
-
-        # Save updated data
-        save_video_job_to_file(job_id, job_data)
-
-        return job_data
-
-    except Exception as e:
-        logger.error(f"Failed to update video job {job_id}: {e}")
-        return None
+async def update_discovery_job(
+    job_id: str, **updates: Any
+) -> Optional[Dict[str, Any]]:
+    return await DiscoveryJobManager.update_job(job_id, **updates)
 
 
 # =============================================
@@ -1647,7 +1609,7 @@ def update_video_job(job_id: str, **updates) -> Optional[Dict[str, Any]]:
 async def fetch_channel_videos_task(job_id: str, channel_name: str):
     """
     Background task to fetch all videos from a channel with timeout protection.
-    Updates job status in video_jobs dictionary.
+    Updates shared PostgreSQL discovery-job state.
     """
     try:
         logger.info(
@@ -1674,7 +1636,7 @@ async def fetch_channel_videos_task(job_id: str, channel_name: str):
             )
 
             # Update job with success
-            update_video_job(
+            await update_discovery_job(
                 job_id,
                 status="completed",
                 channel_info=channel_info,
@@ -1694,7 +1656,7 @@ async def fetch_channel_videos_task(job_id: str, channel_name: str):
 
         except asyncio.TimeoutError:
             error_msg = f"Timeout after {timeout_seconds} seconds"
-            update_video_job(
+            await update_discovery_job(
                 job_id, status="failed", error=error_msg, end_time=time.time()
             )
             logger.error(
@@ -1703,7 +1665,7 @@ async def fetch_channel_videos_task(job_id: str, channel_name: str):
 
     except Exception as e:
         error_msg = f"Error fetching videos: {str(e)}"
-        update_video_job(job_id, status="failed", error=error_msg, end_time=time.time())
+        await update_discovery_job(job_id, status="failed", error=error_msg, end_time=time.time())
         logger.error(
             f"Error in background task for channel {channel_name} (job: {job_id}): {error_msg}",
             exc_info=True,
@@ -1713,7 +1675,7 @@ async def fetch_channel_videos_task(job_id: str, channel_name: str):
 async def fetch_playlist_videos_task(job_id: str, playlist_id: str):
     """
     Background task to fetch all videos from a playlist with timeout protection.
-    Updates job status in video_jobs dictionary.
+    Updates shared PostgreSQL discovery-job state.
     """
     try:
         logger.info(
@@ -1739,7 +1701,7 @@ async def fetch_playlist_videos_task(job_id: str, playlist_id: str):
             )
 
             # Update job with success
-            update_video_job(
+            await update_discovery_job(
                 job_id,
                 status="completed",
                 playlist_info=playlist_info,
@@ -1759,7 +1721,7 @@ async def fetch_playlist_videos_task(job_id: str, playlist_id: str):
 
         except asyncio.TimeoutError:
             error_msg = f"Timeout after {timeout_seconds} seconds"
-            update_video_job(
+            await update_discovery_job(
                 job_id, status="failed", error=error_msg, end_time=time.time()
             )
             logger.error(
@@ -1768,7 +1730,7 @@ async def fetch_playlist_videos_task(job_id: str, playlist_id: str):
 
     except Exception as e:
         error_msg = f"Error fetching videos: {str(e)}"
-        update_video_job(job_id, status="failed", error=error_msg, end_time=time.time())
+        await update_discovery_job(job_id, status="failed", error=error_msg, end_time=time.time())
         logger.error(
             f"Error in background task for playlist {playlist_id} (job: {job_id}): {error_msg}",
             exc_info=True,
@@ -1798,7 +1760,7 @@ async def fetch_channel_playlists_task(job_id: str, channel_name: str):
             )
         except asyncio.TimeoutError:
             error_msg = f"Timeout after {timeout_seconds} seconds"
-            update_video_job(
+            await update_discovery_job(
                 job_id, status="failed", error=error_msg, end_time=time.time()
             )
             logger.error(
@@ -1814,7 +1776,7 @@ async def fetch_channel_playlists_task(job_id: str, channel_name: str):
             "remaining": total_playlists,
         }
 
-        update_video_job(
+        await update_discovery_job(
             job_id,
             status="processing",
             stage="enriching_playlist_metadata",
@@ -1825,7 +1787,7 @@ async def fetch_channel_playlists_task(job_id: str, channel_name: str):
         )
 
         if total_playlists == 0:
-            update_video_job(
+            await update_discovery_job(
                 job_id,
                 status="completed",
                 stage="completed",
@@ -1880,7 +1842,7 @@ async def fetch_channel_playlists_task(job_id: str, channel_name: str):
             updates_since_flush += 1
 
             if updates_since_flush >= update_interval:
-                update_video_job(
+                await update_discovery_job(
                     job_id,
                     playlists=playlists,
                     metadata_enrichment=progress,
@@ -1888,7 +1850,7 @@ async def fetch_channel_playlists_task(job_id: str, channel_name: str):
                 )
                 updates_since_flush = 0
 
-        update_video_job(
+        await update_discovery_job(
             job_id,
             status="completed",
             stage="completed",
@@ -1904,7 +1866,7 @@ async def fetch_channel_playlists_task(job_id: str, channel_name: str):
 
     except Exception as e:
         error_msg = f"Error fetching playlists: {str(e)}"
-        update_video_job(job_id, status="failed", error=error_msg, end_time=time.time())
+        await update_discovery_job(job_id, status="failed", error=error_msg, end_time=time.time())
         logger.error(
             f"Error in background playlist task for channel {channel_name} (job: {job_id}): {error_msg}",
             exc_info=True,
@@ -2316,8 +2278,13 @@ async def list_all_channel_videos(
             "channel_info": None,
         }
 
-        # Save job to persistent storage
-        save_video_job_to_file(job_id, job_data)
+        await create_discovery_job(
+            job_id,
+            job_data,
+            job_type="channel_videos",
+            source_type="channel",
+            source_id=channel_name,
+        )
 
         # Start background task
         background_tasks.add_task(fetch_channel_videos_task, job_id, channel_name)
@@ -2364,7 +2331,13 @@ async def list_all_channel_playlists(
             "channel_info": None,
         }
 
-        save_video_job_to_file(job_id, job_data)
+        await create_discovery_job(
+            job_id,
+            job_data,
+            job_type="channel_playlists",
+            source_type="channel",
+            source_id=channel_name,
+        )
         background_tasks.add_task(fetch_channel_playlists_task, job_id, channel_name)
 
         return {
@@ -2672,8 +2645,7 @@ async def get_videos_fetch_status(
     Check the status of a video fetching job and return results if complete.
     """
     try:
-        # Load job from file
-        job = load_video_job_from_file(job_id)
+        job = await load_discovery_job(job_id, stale_after_minutes=6)
         if job is None:
             raise HTTPException(status_code=404, detail="Job not found")
 
@@ -2743,7 +2715,7 @@ async def get_playlists_fetch_status(
     Returns partial playlists while metadata enrichment is in progress.
     """
     try:
-        job = load_video_job_from_file(job_id)
+        job = await load_discovery_job(job_id, stale_after_minutes=12)
         if job is None:
             raise HTTPException(status_code=404, detail="Job not found")
 
@@ -3061,8 +3033,13 @@ async def list_all_playlist_videos(
             "playlist_info": None,
         }
 
-        # Save job to persistent storage
-        save_video_job_to_file(job_id, job_data)
+        await create_discovery_job(
+            job_id,
+            job_data,
+            job_type="playlist_videos",
+            source_type="playlist",
+            source_id=clean_playlist_id,
+        )
 
         # Start background task
         background_tasks.add_task(fetch_playlist_videos_task, job_id, clean_playlist_id)
@@ -3434,7 +3411,7 @@ async def _create_playlist_download_job(
 
 async def create_batch_playlist_download_jobs_task(batch_job_id: str):
     """Background task to create child playlist jobs with throttled concurrency."""
-    job = load_video_job_from_file(batch_job_id)
+    job = await load_discovery_job(batch_job_id)
     if not job:
         logger.error(f"Batch playlist job {batch_job_id} not found")
         return
@@ -3512,7 +3489,7 @@ async def create_batch_playlist_download_jobs_task(batch_job_id: str):
             finally:
                 async with update_lock:
                     processed_playlists += 1
-                    update_video_job(
+                    await update_discovery_job(
                         batch_job_id,
                         processed_playlists=processed_playlists,
                         created_jobs=created_jobs,
@@ -3528,7 +3505,7 @@ async def create_batch_playlist_download_jobs_task(batch_job_id: str):
         await asyncio.gather(*tasks)
 
         final_status = "completed" if not failed_playlists else "completed_with_errors"
-        update_video_job(
+        await update_discovery_job(
             batch_job_id,
             status=final_status,
             stage="completed",
@@ -3551,7 +3528,7 @@ async def create_batch_playlist_download_jobs_task(batch_job_id: str):
             f"Batch playlist job {batch_job_id} failed unexpectedly: {str(e)}",
             exc_info=True,
         )
-        update_video_job(
+        await update_discovery_job(
             batch_job_id,
             status="failed",
             stage="failed",
@@ -3608,7 +3585,13 @@ async def download_selected_playlists_batch(
     }
 
     try:
-        save_video_job_to_file(batch_job_id, job_data)
+        await create_discovery_job(
+            batch_job_id,
+            job_data,
+            job_type="playlist_download_batch",
+            source_type="channel",
+            source_id=request.channel_name,
+        )
 
         background_tasks.add_task(
             create_batch_playlist_download_jobs_task,
@@ -3635,7 +3618,7 @@ async def download_selected_playlists_batch(
 async def get_batch_playlist_download_status(batch_job_id: str):
     """Check status of a batch playlist child-job creation request."""
     try:
-        job = load_video_job_from_file(batch_job_id)
+        job = await load_discovery_job(batch_job_id, stale_after_minutes=30)
         if job is None:
             raise HTTPException(status_code=404, detail="Batch job not found")
 

--- a/tests/test_discovery_job_manager.py
+++ b/tests/test_discovery_job_manager.py
@@ -1,0 +1,73 @@
+import asyncio
+import json
+from contextlib import asynccontextmanager
+
+from db_youtube_transcripts import discovery_job_manager as discovery_module
+from db_youtube_transcripts.discovery_job_manager import DiscoveryJobManager
+
+
+class FakeConnection:
+    def __init__(self, record=None):
+        self.record = record
+        self.calls = []
+
+    async def execute(self, query, *args):
+        self.calls.append(("execute", query, args))
+        return "UPDATE 1"
+
+    async def fetchrow(self, query, *args):
+        self.calls.append(("fetchrow", query, args))
+        return self.record
+
+
+def connection_context(connection):
+    @asynccontextmanager
+    async def context():
+        yield connection
+
+    return context
+
+
+def test_discovery_job_round_trip_uses_shared_json_payload(monkeypatch):
+    connection = FakeConnection(
+        {
+            "payload": json.dumps(
+                {"job_id": "job-id", "status": "processing", "videos": []}
+            ),
+            "status": "completed",
+            "error_message": None,
+        }
+    )
+    monkeypatch.setattr(
+        discovery_module, "get_db_transaction", connection_context(connection)
+    )
+
+    job = asyncio.run(DiscoveryJobManager.get_job("job-id", 6))
+
+    assert job == {"job_id": "job-id", "status": "completed", "videos": []}
+    assert "make_interval(mins => $2::int)" in connection.calls[0][1]
+    assert connection.calls[-1][2] == ("job-id",)
+
+
+def test_discovery_updates_do_not_revive_terminal_jobs(monkeypatch):
+    connection = FakeConnection(
+        {
+            "payload": {"status": "completed", "videos": [{"id": "video"}]},
+            "status": "completed",
+            "error_message": None,
+        }
+    )
+    monkeypatch.setattr(
+        discovery_module, "get_db_connection", connection_context(connection)
+    )
+
+    result = asyncio.run(
+        DiscoveryJobManager.update_job(
+            "job-id", status="completed", videos=[{"id": "video"}]
+        )
+    )
+
+    assert result["status"] == "completed"
+    assert "status NOT IN ('completed', 'completed_with_errors', 'failed')" in (
+        connection.calls[0][1]
+    )

--- a/tests/test_playlist_job_lifecycle.py
+++ b/tests/test_playlist_job_lifecycle.py
@@ -125,12 +125,38 @@ def test_cancelled_job_ignores_late_lambda_result(monkeypatch):
 
 
 def test_website_video_status_preserves_not_found(monkeypatch):
-    monkeypatch.setattr(transcript_api, "load_video_job_from_file", lambda job_id: None)
+    monkeypatch.setattr(
+        transcript_api, "load_discovery_job", AsyncMock(return_value=None)
+    )
 
     with pytest.raises(HTTPException) as exc_info:
         asyncio.run(transcript_api.get_videos_fetch_status("missing"))
 
     assert exc_info.value.status_code == 404
+
+
+def test_playlist_discovery_is_persisted_before_background_work(monkeypatch):
+    create_job = AsyncMock(return_value="job-id")
+    monkeypatch.setattr(transcript_api, "create_discovery_job", create_job)
+    monkeypatch.setattr(
+        transcript_api.youtube_service,
+        "extract_playlist_id",
+        lambda playlist_id: "playlist-id",
+    )
+    background_tasks = transcript_api.BackgroundTasks()
+
+    response = asyncio.run(
+        transcript_api.list_all_playlist_videos("playlist-id", background_tasks)
+    )
+
+    create_job.assert_awaited_once()
+    assert response["job_id"] == create_job.await_args.args[0]
+    assert create_job.await_args.kwargs == {
+        "job_type": "playlist_videos",
+        "source_type": "playlist",
+        "source_id": "playlist-id",
+    }
+    assert len(background_tasks.tasks) == 1
 
 
 def test_developer_cancel_response_keeps_partial_download(monkeypatch):


### PR DESCRIPTION
Implemented across both repositories.
Backend:
Added PostgreSQL-backed discovery jobs with 48-hour retention.
Migrated video, playlist, channel-playlist, and batch discovery flows away from local JSON files.
Added stale-worker detection and terminal-state race protection.
Applied the production database migration and verified a real create/read/update/delete round trip.
Primary files: [discovery_job_manager.py](C:/Users/franb/projects/youtube-ai/youtube-channel-to-gpt/db_youtube_transcripts/discovery_job_manager.py), [transcript_api.py](C:/Users/franb/projects/youtube-ai/youtube-channel-to-gpt/src/transcript_api.py).
Frontend:
Removed the process-local Map and Vercel fire-and-forget polling.
Creation now returns FastAPI’s actual job ID.
Status route directly proxies FastAPI with caching disabled.
Browser polling treats 404 as terminal while retrying transient 429/5xx/network errors.
Primary files: [all-videos route](C:/Users/franb/projects/youtube-transcript-v0-chakra/app/api/channel-transcript/all-videos/route.ts), [status route](C:/Users/franb/projects/youtube-transcript-v0-chakra/app/api/channel-transcript/videos-status/[jobId]/route.ts), [try-it-out.tsx](C:/Users/franb/projects/youtube-transcript-v0-chakra/components/try-it-out.tsx).